### PR TITLE
Alway re-import scenes and fix re-import always issue on Godot 3.2.3

### DIFF
--- a/LDtkImportPlugin.gd
+++ b/LDtkImportPlugin.gd
@@ -13,20 +13,20 @@ func get_recognized_extensions():
 	return ["ldtk"]
 	
 func get_save_extension():
-	return "tscn"
+	return ""
 	
 func get_resource_type():
-	return "Scenes"
+	return "TextFile"
 	
 func get_import_options(preset):
 	return []
 	
-func import(source_file, save_path, options, platform_variants, gen_files):
+func import(source_file, save_path, options, r_platform_variants, r_gen_files):
 	importEngine = preload("ImportEngine.gd").new()
 	var ldtkFile = importEngine.load_ldtk_file(source_file)
 	if ldtkFile.error != OK:
 		return ldtkFile.error
-		
+
 	save_path = source_file.get_basename()
 	var tilsetPath = save_path.plus_file("tilesets")
 	
@@ -35,17 +35,19 @@ func import(source_file, save_path, options, platform_variants, gen_files):
 		var error = directory.make_dir_recursive(tilsetPath)
 		if error != OK:
 			return error
-		
+
 	var layerDefs = importEngine.load_layer_defs(ldtkFile.defs)
 	var tilesets = importEngine.load_tilesets(ldtkFile.defs, source_file.get_base_dir(), tilsetPath)
 	
 	for level in ldtkFile.levels:
-		var scenePath = importEngine.generate_level(level, layerDefs, tilesets, save_path, get_save_extension())
+		var scenePath = importEngine.generate_level(level, layerDefs, tilesets, save_path)
 		if scenePath:
-			gen_files.append(scenePath)
-			
+			r_gen_files.append(scenePath)
+
 	for tileset in tilesets.values():
 		if ResourceSaver.save(tileset.path, tileset.tileset) == OK:
-			gen_files.append(tileset.path)
-	
+			r_gen_files.append(tileset.path)
+		else:
+			print_debug("error saving tileset file")
+
 	return OK


### PR DESCRIPTION
I found a few issues when using your plugin. Mainly an always re-import issue (whenever I alt-tab'd it would re-import and show 3 errors on the Output window), and some tiles not updating when re-importing.

My take on it was to change "get_save_extension()" to have an empty string (resolves one of the errors), and some file closes that might have been missing.

Also removed the part that would re-use the current scene if existed, it was causing issues with some tiles not updating, mainly the ones when you use rules to change adjacent tiles (for some reason they weren't updating correctly. It also makes sure that it uses the latest version in LDtk, removing any changes made by the user.

And added some prints to make sure some of the errors are logged in case they happen (not sure what is the correct way of doing that in Godot to show as error, so I used that).

Let me know if there' anything you don't want from it, or feel free to close this if you don't feel these changes make any sense.